### PR TITLE
1.29 Add up button to each category activity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,16 +17,40 @@
         </activity>
         <activity
             android:name=".PhrasesActivity"
-            android:label="@string/category_phrases" />
+            android:label="@string/category_phrases"
+            android:parentActivityName=".MainActivity">
+            <!-- Parent activity meta-data to support 4.0 and lower -->
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".MainActivity"/>
+        </activity>
         <activity
             android:name=".ColorsActivity"
-            android:label="@string/category_colors" />
+            android:label="@string/category_colors"
+            android:parentActivityName=".MainActivity">
+            <!-- Parent activity meta-data to support 4.0 and lower -->
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".MainActivity"/>
+        </activity>
         <activity
             android:name=".NumbersActivity"
-            android:label="@string/category_numbers" />
+            android:label="@string/category_numbers"
+            android:parentActivityName=".MainActivity">
+            <!-- Parent activity meta-data to support 4.0 and lower -->
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".MainActivity"/>
+        </activity>
         <activity
             android:name=".FamilyActivity"
-            android:label="@string/category_family" />
+            android:label="@string/category_family"
+            android:parentActivityName=".MainActivity">
+            <!-- Parent activity meta-data to support 4.0 and lower -->
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".MainActivity"/>
+        </activity>
     </application>
 
 </manifest>


### PR DESCRIPTION
Addresses #10.

Adds the attribute `parentActivityName='.MainActivity` and the following meta-data tag to each category activity:

```
<meta-data
    android:name="android.support.PARENT_ACTIVITY"
    android:value=".MainActivity"/>
```

Copied comment `<!-- Parent activity meta-data to support 4.0 and lower -->` from the documentation page: http://developer.android.com/training/implementing-navigation/ancestral.html, hoping it's useful for students.