### PR TITLE
1.34 Move strings to strings.xml

### DIFF
--- a/app/src/main/java/com/example/android/miwok/ColorsFragment.java
+++ b/app/src/main/java/com/example/android/miwok/ColorsFragment.java
@@ -71,16 +71,16 @@ public class ColorsFragment extends Fragment {
 
         // Create list of words
         final ArrayList<Word> words = new ArrayList<Word>();
-        words.add(new Word("red", "weṭeṭṭi", R.drawable.color_red, R.raw.color_red));
-        words.add(new Word("dusty yellow", "ṭopiisә", R.drawable.color_dusty_yellow,
+        words.add(new Word(getString(R.string.color_red), getString(R.string.miwok_color_red), R.drawable.color_red, R.raw.color_red));
+        words.add(new Word(getString(R.string.color_dusty_yellow), getString(R.string.miwok_color_dusty_yellow), R.drawable.color_dusty_yellow,
                 R.raw.color_dusty_yellow));
-        words.add(new Word("mustard yellow", "chiwiiṭә", R.drawable.color_mustard_yellow,
+        words.add(new Word(getString(R.string.color_mustard_yellow), getString(R.string.miwok_color_mustard_yellow), R.drawable.color_mustard_yellow,
                 R.raw.color_mustard_yellow));
-        words.add(new Word("green", "chokokki", R.drawable.color_green, R.raw.color_green));
-        words.add(new Word("brown", "ṭakaakki", R.drawable.color_brown, R.raw.color_brown));
-        words.add(new Word("black", "kululli", R.drawable.color_black, R.raw.color_black));
-        words.add(new Word("gray", "ṭopoppi", R.drawable.color_gray, R.raw.color_gray));
-        words.add(new Word("white", "kelelli", R.drawable.color_white, R.raw.color_white));
+        words.add(new Word(getString(R.string.color_green), getString(R.string.miwok_color_green), R.drawable.color_green, R.raw.color_green));
+        words.add(new Word(getString(R.string.color_brown), getString(R.string.miwok_color_brown), R.drawable.color_brown, R.raw.color_brown));
+        words.add(new Word(getString(R.string.color_black), getString(R.string.miwok_color_black), R.drawable.color_black, R.raw.color_black));
+        words.add(new Word(getString(R.string.color_gray), getString(R.string.miwok_color_gray), R.drawable.color_gray, R.raw.color_gray));
+        words.add(new Word(getString(R.string.color_white), getString(R.string.miwok_color_white), R.drawable.color_white, R.raw.color_white));
 
         // Create an {@link WordAdapter}, whose data source is a list of {@link Word}s. The
         // adapter knows how to create list items for each item in the list.

--- a/app/src/main/java/com/example/android/miwok/ColorsFragment.java
+++ b/app/src/main/java/com/example/android/miwok/ColorsFragment.java
@@ -71,16 +71,16 @@ public class ColorsFragment extends Fragment {
 
         // Create list of words
         final ArrayList<Word> words = new ArrayList<Word>();
-        words.add(new Word(getString(R.string.color_red), getString(R.string.miwok_color_red), R.drawable.color_red, R.raw.color_red));
-        words.add(new Word(getString(R.string.color_dusty_yellow), getString(R.string.miwok_color_dusty_yellow), R.drawable.color_dusty_yellow,
+        words.add(new Word(R.string.color_red, R.string.miwok_color_red, R.drawable.color_red, R.raw.color_red));
+        words.add(new Word(R.string.color_dusty_yellow, R.string.miwok_color_dusty_yellow, R.drawable.color_dusty_yellow,
                 R.raw.color_dusty_yellow));
-        words.add(new Word(getString(R.string.color_mustard_yellow), getString(R.string.miwok_color_mustard_yellow), R.drawable.color_mustard_yellow,
+        words.add(new Word(R.string.color_mustard_yellow, R.string.miwok_color_mustard_yellow, R.drawable.color_mustard_yellow,
                 R.raw.color_mustard_yellow));
-        words.add(new Word(getString(R.string.color_green), getString(R.string.miwok_color_green), R.drawable.color_green, R.raw.color_green));
-        words.add(new Word(getString(R.string.color_brown), getString(R.string.miwok_color_brown), R.drawable.color_brown, R.raw.color_brown));
-        words.add(new Word(getString(R.string.color_black), getString(R.string.miwok_color_black), R.drawable.color_black, R.raw.color_black));
-        words.add(new Word(getString(R.string.color_gray), getString(R.string.miwok_color_gray), R.drawable.color_gray, R.raw.color_gray));
-        words.add(new Word(getString(R.string.color_white), getString(R.string.miwok_color_white), R.drawable.color_white, R.raw.color_white));
+        words.add(new Word(R.string.color_green, R.string.miwok_color_green, R.drawable.color_green, R.raw.color_green));
+        words.add(new Word(R.string.color_brown, R.string.miwok_color_brown, R.drawable.color_brown, R.raw.color_brown));
+        words.add(new Word(R.string.color_black, R.string.miwok_color_black, R.drawable.color_black, R.raw.color_black));
+        words.add(new Word(R.string.color_gray, R.string.miwok_color_gray, R.drawable.color_gray, R.raw.color_gray));
+        words.add(new Word(R.string.color_white, R.string.miwok_color_white, R.drawable.color_white, R.raw.color_white));
 
         // Create an {@link WordAdapter}, whose data source is a list of {@link Word}s. The
         // adapter knows how to create list items for each item in the list.

--- a/app/src/main/java/com/example/android/miwok/FamilyFragment.java
+++ b/app/src/main/java/com/example/android/miwok/FamilyFragment.java
@@ -71,21 +71,21 @@ public class FamilyFragment extends Fragment {
 
         // Create list of words
         final ArrayList<Word> words = new ArrayList<Word>();
-        words.add(new Word("father", "әpә", R.drawable.family_father, R.raw.family_father));
-        words.add(new Word("mother", "әṭa", R.drawable.family_mother, R.raw.family_mother));
-        words.add(new Word("son", "angsi", R.drawable.family_son, R.raw.family_son));
-        words.add(new Word("daughter", "tune", R.drawable.family_daughter, R.raw.family_daughter));
-        words.add(new Word("older brother", "taachi", R.drawable.family_older_brother,
+        words.add(new Word(getString(R.string.family_father), getString(R.string.miwok_family_father), R.drawable.family_father, R.raw.family_father));
+        words.add(new Word(getString(R.string.family_mother), getString(R.string.miwok_family_mother), R.drawable.family_mother, R.raw.family_mother));
+        words.add(new Word(getString(R.string.family_son), getString(R.string.miwok_family_son), R.drawable.family_son, R.raw.family_son));
+        words.add(new Word(getString(R.string.family_daughter), getString(R.string.miwok_family_daughter), R.drawable.family_daughter, R.raw.family_daughter));
+        words.add(new Word(getString(R.string.family_older_brother), getString(R.string.miwok_family_older_brother), R.drawable.family_older_brother,
                 R.raw.family_older_brother));
-        words.add(new Word("younger brother", "chalitti", R.drawable.family_younger_brother,
+        words.add(new Word(getString(R.string.family_younger_brother), getString(R.string.miwok_family_younger_brother), R.drawable.family_younger_brother,
                 R.raw.family_younger_brother));
-        words.add(new Word("older sister", "teṭe", R.drawable.family_older_sister,
+        words.add(new Word(getString(R.string.family_older_sister), getString(R.string.miwok_family_older_sister), R.drawable.family_older_sister,
                 R.raw.family_older_sister));
-        words.add(new Word("younger sister", "kolliti", R.drawable.family_younger_sister,
+        words.add(new Word(getString(R.string.family_younger_sister), getString(R.string.miwok_family_younger_sister), R.drawable.family_younger_sister,
                 R.raw.family_younger_sister));
-        words.add(new Word("grandmother", "ama", R.drawable.family_grandmother,
+        words.add(new Word(getString(R.string.family_grandmother), getString(R.string.miwok_family_grandmother), R.drawable.family_grandmother,
                 R.raw.family_grandmother));
-        words.add(new Word("grandfather", "paapa", R.drawable.family_grandfather,
+        words.add(new Word(getString(R.string.family_grandfather), getString(R.string.miwok_family_grandfather), R.drawable.family_grandfather,
                 R.raw.family_grandfather));
 
         // Create an {@link WordAdapter}, whose data source is a list of {@link Word}s. The

--- a/app/src/main/java/com/example/android/miwok/FamilyFragment.java
+++ b/app/src/main/java/com/example/android/miwok/FamilyFragment.java
@@ -71,21 +71,21 @@ public class FamilyFragment extends Fragment {
 
         // Create list of words
         final ArrayList<Word> words = new ArrayList<Word>();
-        words.add(new Word(getString(R.string.family_father), getString(R.string.miwok_family_father), R.drawable.family_father, R.raw.family_father));
-        words.add(new Word(getString(R.string.family_mother), getString(R.string.miwok_family_mother), R.drawable.family_mother, R.raw.family_mother));
-        words.add(new Word(getString(R.string.family_son), getString(R.string.miwok_family_son), R.drawable.family_son, R.raw.family_son));
-        words.add(new Word(getString(R.string.family_daughter), getString(R.string.miwok_family_daughter), R.drawable.family_daughter, R.raw.family_daughter));
-        words.add(new Word(getString(R.string.family_older_brother), getString(R.string.miwok_family_older_brother), R.drawable.family_older_brother,
+        words.add(new Word(R.string.family_father, R.string.miwok_family_father, R.drawable.family_father, R.raw.family_father));
+        words.add(new Word(R.string.family_mother, R.string.miwok_family_mother, R.drawable.family_mother, R.raw.family_mother));
+        words.add(new Word(R.string.family_son, R.string.miwok_family_son, R.drawable.family_son, R.raw.family_son));
+        words.add(new Word(R.string.family_daughter, R.string.miwok_family_daughter, R.drawable.family_daughter, R.raw.family_daughter));
+        words.add(new Word(R.string.family_older_brother, R.string.miwok_family_older_brother, R.drawable.family_older_brother,
                 R.raw.family_older_brother));
-        words.add(new Word(getString(R.string.family_younger_brother), getString(R.string.miwok_family_younger_brother), R.drawable.family_younger_brother,
+        words.add(new Word(R.string.family_younger_brother, R.string.miwok_family_younger_brother, R.drawable.family_younger_brother,
                 R.raw.family_younger_brother));
-        words.add(new Word(getString(R.string.family_older_sister), getString(R.string.miwok_family_older_sister), R.drawable.family_older_sister,
+        words.add(new Word(R.string.family_older_sister, R.string.miwok_family_older_sister, R.drawable.family_older_sister,
                 R.raw.family_older_sister));
-        words.add(new Word(getString(R.string.family_younger_sister), getString(R.string.miwok_family_younger_sister), R.drawable.family_younger_sister,
+        words.add(new Word(R.string.family_younger_sister, R.string.miwok_family_younger_sister, R.drawable.family_younger_sister,
                 R.raw.family_younger_sister));
-        words.add(new Word(getString(R.string.family_grandmother), getString(R.string.miwok_family_grandmother), R.drawable.family_grandmother,
+        words.add(new Word(R.string.family_grandmother, R.string.miwok_family_grandmother, R.drawable.family_grandmother,
                 R.raw.family_grandmother));
-        words.add(new Word(getString(R.string.family_grandfather), getString(R.string.miwok_family_grandfather), R.drawable.family_grandfather,
+        words.add(new Word(R.string.family_grandfather, R.string.miwok_family_grandfather, R.drawable.family_grandfather,
                 R.raw.family_grandfather));
 
         // Create an {@link WordAdapter}, whose data source is a list of {@link Word}s. The

--- a/app/src/main/java/com/example/android/miwok/NumbersFragment.java
+++ b/app/src/main/java/com/example/android/miwok/NumbersFragment.java
@@ -71,16 +71,16 @@ public class NumbersFragment extends Fragment {
 
         // Create list of words
         final ArrayList<Word> words = new ArrayList<Word>();
-        words.add(new Word(getString(R.string.number_one), getString(R.string.miwok_number_one), R.drawable.number_one, R.raw.number_one));
-        words.add(new Word(getString(R.string.number_two), getString(R.string.miwok_number_two), R.drawable.number_two, R.raw.number_two));
-        words.add(new Word(getString(R.string.number_three), getString(R.string.miwok_number_three), R.drawable.number_three, R.raw.number_three));
-        words.add(new Word(getString(R.string.number_four), getString(R.string.miwok_number_four), R.drawable.number_four, R.raw.number_four));
-        words.add(new Word(getString(R.string.number_five), getString(R.string.miwok_number_five), R.drawable.number_five, R.raw.number_five));
-        words.add(new Word(getString(R.string.number_six), getString(R.string.miwok_number_six), R.drawable.number_six, R.raw.number_six));
-        words.add(new Word(getString(R.string.number_seven), getString(R.string.miwok_number_seven), R.drawable.number_seven, R.raw.number_seven));
-        words.add(new Word(getString(R.string.number_eight), getString(R.string.miwok_number_eight), R.drawable.number_eight, R.raw.number_eight));
-        words.add(new Word(getString(R.string.number_nine), getString(R.string.miwok_number_nine), R.drawable.number_nine, R.raw.number_nine));
-        words.add(new Word(getString(R.string.number_ten), getString(R.string.miwok_number_ten), R.drawable.number_ten, R.raw.number_ten));
+        words.add(new Word(R.string.number_one, R.string.miwok_number_one, R.drawable.number_one, R.raw.number_one));
+        words.add(new Word(R.string.number_two, R.string.miwok_number_two, R.drawable.number_two, R.raw.number_two));
+        words.add(new Word(R.string.number_three, R.string.miwok_number_three, R.drawable.number_three, R.raw.number_three));
+        words.add(new Word(R.string.number_four, R.string.miwok_number_four, R.drawable.number_four, R.raw.number_four));
+        words.add(new Word(R.string.number_five, R.string.miwok_number_five, R.drawable.number_five, R.raw.number_five));
+        words.add(new Word(R.string.number_six, R.string.miwok_number_six, R.drawable.number_six, R.raw.number_six));
+        words.add(new Word(R.string.number_seven, R.string.miwok_number_seven, R.drawable.number_seven, R.raw.number_seven));
+        words.add(new Word(R.string.number_eight, R.string.miwok_number_eight, R.drawable.number_eight, R.raw.number_eight));
+        words.add(new Word(R.string.number_nine, R.string.miwok_number_nine, R.drawable.number_nine, R.raw.number_nine));
+        words.add(new Word(R.string.number_ten, R.string.miwok_number_ten, R.drawable.number_ten, R.raw.number_ten));
 
         // Create an {@link WordAdapter}, whose data source is a list of {@link Word}s. The
         // adapter knows how to create list items for each item in the list.

--- a/app/src/main/java/com/example/android/miwok/NumbersFragment.java
+++ b/app/src/main/java/com/example/android/miwok/NumbersFragment.java
@@ -71,16 +71,16 @@ public class NumbersFragment extends Fragment {
 
         // Create list of words
         final ArrayList<Word> words = new ArrayList<Word>();
-        words.add(new Word("one", "lutti", R.drawable.number_one, R.raw.number_one));
-        words.add(new Word("two", "otiiko", R.drawable.number_two, R.raw.number_two));
-        words.add(new Word("three", "tolookosu", R.drawable.number_three, R.raw.number_three));
-        words.add(new Word("four", "oyyisa", R.drawable.number_four, R.raw.number_four));
-        words.add(new Word("five", "massokka", R.drawable.number_five, R.raw.number_five));
-        words.add(new Word("six", "temmokka", R.drawable.number_six, R.raw.number_six));
-        words.add(new Word("seven", "kenekaku", R.drawable.number_seven, R.raw.number_seven));
-        words.add(new Word("eight", "kawinta", R.drawable.number_eight, R.raw.number_eight));
-        words.add(new Word("nine", "wo’e", R.drawable.number_nine, R.raw.number_nine));
-        words.add(new Word("ten", "na’aacha", R.drawable.number_ten, R.raw.number_ten));
+        words.add(new Word(getString(R.string.number_one), getString(R.string.miwok_number_one), R.drawable.number_one, R.raw.number_one));
+        words.add(new Word(getString(R.string.number_two), getString(R.string.miwok_number_two), R.drawable.number_two, R.raw.number_two));
+        words.add(new Word(getString(R.string.number_three), getString(R.string.miwok_number_three), R.drawable.number_three, R.raw.number_three));
+        words.add(new Word(getString(R.string.number_four), getString(R.string.miwok_number_four), R.drawable.number_four, R.raw.number_four));
+        words.add(new Word(getString(R.string.number_five), getString(R.string.miwok_number_five), R.drawable.number_five, R.raw.number_five));
+        words.add(new Word(getString(R.string.number_six), getString(R.string.miwok_number_six), R.drawable.number_six, R.raw.number_six));
+        words.add(new Word(getString(R.string.number_seven), getString(R.string.miwok_number_seven), R.drawable.number_seven, R.raw.number_seven));
+        words.add(new Word(getString(R.string.number_eight), getString(R.string.miwok_number_eight), R.drawable.number_eight, R.raw.number_eight));
+        words.add(new Word(getString(R.string.number_nine), getString(R.string.miwok_number_nine), R.drawable.number_nine, R.raw.number_nine));
+        words.add(new Word(getString(R.string.number_ten), getString(R.string.miwok_number_ten), R.drawable.number_ten, R.raw.number_ten));
 
         // Create an {@link WordAdapter}, whose data source is a list of {@link Word}s. The
         // adapter knows how to create list items for each item in the list.

--- a/app/src/main/java/com/example/android/miwok/PhrasesFragment.java
+++ b/app/src/main/java/com/example/android/miwok/PhrasesFragment.java
@@ -71,16 +71,16 @@ public class PhrasesFragment extends Fragment {
 
         // Create list of words
         final ArrayList<Word> words = new ArrayList<Word>();
-        words.add(new Word(getString(R.string.phrase_where_are_you_going), getString(R.string.miwok_phrase_where_are_you_going), R.raw.phrase_where_are_you_going));
-        words.add(new Word(getString(R.string.phrase_what_is_your_name), getString(R.string.miwok_phrase_what_is_your_name), R.raw.phrase_what_is_your_name));
-        words.add(new Word(getString(R.string.phrase_my_name_is), getString(R.string.miwok_phrase_my_name_is), R.raw.phrase_my_name_is));
-        words.add(new Word(getString(R.string.phrase_how_are_you_feeling), getString(R.string.miwok_phrase_how_are_you_feeling), R.raw.phrase_how_are_you_feeling));
-        words.add(new Word(getString(R.string.phrase_im_feeling_good), getString(R.string.miwok_phrase_im_feeling_good), R.raw.phrase_im_feeling_good));
-        words.add(new Word(getString(R.string.phrase_are_you_coming), getString(R.string.miwok_phrase_are_you_coming), R.raw.phrase_are_you_coming));
-        words.add(new Word(getString(R.string.phrase_yes_im_coming), getString(R.string.miwok_phrase_yes_im_coming), R.raw.phrase_yes_im_coming));
-        words.add(new Word(getString(R.string.phrase_im_coming), getString(R.string.miwok_phrase_im_coming), R.raw.phrase_im_coming));
-        words.add(new Word(getString(R.string.phrase_lets_go), getString(R.string.miwok_phrase_lets_go), R.raw.phrase_lets_go));
-        words.add(new Word(getString(R.string.phrase_come_here), getString(R.string.miwok_phrase_come_here), R.raw.phrase_come_here));
+        words.add(new Word(R.string.phrase_where_are_you_going, R.string.miwok_phrase_where_are_you_going, R.raw.phrase_where_are_you_going));
+        words.add(new Word(R.string.phrase_what_is_your_name, R.string.miwok_phrase_what_is_your_name, R.raw.phrase_what_is_your_name));
+        words.add(new Word(R.string.phrase_my_name_is, R.string.miwok_phrase_my_name_is, R.raw.phrase_my_name_is));
+        words.add(new Word(R.string.phrase_how_are_you_feeling, R.string.miwok_phrase_how_are_you_feeling, R.raw.phrase_how_are_you_feeling));
+        words.add(new Word(R.string.phrase_im_feeling_good, R.string.miwok_phrase_im_feeling_good, R.raw.phrase_im_feeling_good));
+        words.add(new Word(R.string.phrase_are_you_coming, R.string.miwok_phrase_are_you_coming, R.raw.phrase_are_you_coming));
+        words.add(new Word(R.string.phrase_yes_im_coming, R.string.miwok_phrase_yes_im_coming, R.raw.phrase_yes_im_coming));
+        words.add(new Word(R.string.phrase_im_coming, R.string.miwok_phrase_im_coming, R.raw.phrase_im_coming));
+        words.add(new Word(R.string.phrase_lets_go, R.string.miwok_phrase_lets_go, R.raw.phrase_lets_go));
+        words.add(new Word(R.string.phrase_come_here, R.string.miwok_phrase_come_here, R.raw.phrase_come_here));
         // Create an {@link WordAdapter}, whose data source is a list of {@link Word}s. The
         // adapter knows how to create list items for each item in the list.
         WordAdapter adapter = new WordAdapter(getActivity(), words, R.color.category_phrases);

--- a/app/src/main/java/com/example/android/miwok/PhrasesFragment.java
+++ b/app/src/main/java/com/example/android/miwok/PhrasesFragment.java
@@ -71,17 +71,16 @@ public class PhrasesFragment extends Fragment {
 
         // Create list of words
         final ArrayList<Word> words = new ArrayList<Word>();
-        words.add(new Word("Where are you going?", "minto wuksus", R.raw.phrase_where_are_you_going));
-        words.add(new Word("What is your name?", "tinnә oyaase'nә", R.raw.phrase_what_is_your_name));
-        words.add(new Word("My name is...", "oyaaset...", R.raw.phrase_my_name_is));
-        words.add(new Word("How are you feeling?", "michәksәs?", R.raw.phrase_how_are_you_feeling));
-        words.add(new Word("I’m feeling good.", "kuchi achit", R.raw.phrase_im_feeling_good));
-        words.add(new Word("Are you coming?", "әәnәs'aa?", R.raw.phrase_are_you_coming));
-        words.add(new Word("Yes, I’m coming.", "hәә’ әәnәm", R.raw.phrase_yes_im_coming));
-        words.add(new Word("I’m coming.", "әәnәm", R.raw.phrase_im_coming));
-        words.add(new Word("Let’s go.", "yoowutis", R.raw.phrase_lets_go));
-        words.add(new Word("Come here.", "әnni'nem", R.raw.phrase_come_here));
-
+        words.add(new Word(getString(R.string.phrase_where_are_you_going), getString(R.string.miwok_phrase_where_are_you_going), R.raw.phrase_where_are_you_going));
+        words.add(new Word(getString(R.string.phrase_what_is_your_name), getString(R.string.miwok_phrase_what_is_your_name), R.raw.phrase_what_is_your_name));
+        words.add(new Word(getString(R.string.phrase_my_name_is), getString(R.string.miwok_phrase_my_name_is), R.raw.phrase_my_name_is));
+        words.add(new Word(getString(R.string.phrase_how_are_you_feeling), getString(R.string.miwok_phrase_how_are_you_feeling), R.raw.phrase_how_are_you_feeling));
+        words.add(new Word(getString(R.string.phrase_im_feeling_good), getString(R.string.miwok_phrase_im_feeling_good), R.raw.phrase_im_feeling_good));
+        words.add(new Word(getString(R.string.phrase_are_you_coming), getString(R.string.miwok_phrase_are_you_coming), R.raw.phrase_are_you_coming));
+        words.add(new Word(getString(R.string.phrase_yes_im_coming), getString(R.string.miwok_phrase_yes_im_coming), R.raw.phrase_yes_im_coming));
+        words.add(new Word(getString(R.string.phrase_im_coming), getString(R.string.miwok_phrase_im_coming), R.raw.phrase_im_coming));
+        words.add(new Word(getString(R.string.phrase_lets_go), getString(R.string.miwok_phrase_lets_go), R.raw.phrase_lets_go));
+        words.add(new Word(getString(R.string.phrase_come_here), getString(R.string.miwok_phrase_come_here), R.raw.phrase_come_here));
         // Create an {@link WordAdapter}, whose data source is a list of {@link Word}s. The
         // adapter knows how to create list items for each item in the list.
         WordAdapter adapter = new WordAdapter(getActivity(), words, R.color.category_phrases);

--- a/app/src/main/java/com/example/android/miwok/Word.java
+++ b/app/src/main/java/com/example/android/miwok/Word.java
@@ -7,10 +7,10 @@ package com.example.android.miwok;
 public class Word {
 
     /** Default translation for the word */
-    private String mDefaultTranslation;
+    private int mDefaultTranslationId;
 
     /** Miwok translation for the word */
-    private String mMiwokTranslation;
+    private int mMiwokTranslationId;
 
     /** Audio resource ID for the word */
     private int mAudioResourceId;
@@ -24,31 +24,31 @@ public class Word {
     /**
      * Create a new Word object.
      *
-     * @param defaultTranslation is the word in a language that the user is already familiar with
+     * @param defaultTranslationId is the word in a language that the user is already familiar with
      *                           (such as English)
-     * @param miwokTranslation is the word in the Miwok language
+     * @param miwokTranslationId is the word in the Miwok language
      * @param audioResourceId is the resource ID for the audio file associated with this word
      */
-    public Word(String defaultTranslation, String miwokTranslation, int audioResourceId) {
-        mDefaultTranslation = defaultTranslation;
-        mMiwokTranslation = miwokTranslation;
+    public Word(int defaultTranslationId, int miwokTranslationId, int audioResourceId) {
+        mDefaultTranslationId = defaultTranslationId;
+        mMiwokTranslationId = miwokTranslationId;
         mAudioResourceId = audioResourceId;
     }
 
     /**
      * Create a new Word object.
      *
-     * @param defaultTranslation is the word in a language that the user is already familiar with
+     * @param defaultTranslationId is the word in a language that the user is already familiar with
      *                           (such as English)
-     * @param miwokTranslation is the word in the Miwok language
+     * @param miwokTranslationId is the word in the Miwok language
      * @param imageResourceId is the drawable resource ID for the image associated with the word
      * @param audioResourceId is the resource ID for the audio file associated with this word
      *
      */
-    public Word(String defaultTranslation, String miwokTranslation, int imageResourceId,
+    public Word(int defaultTranslationId, int miwokTranslationId, int imageResourceId,
                 int audioResourceId) {
-        mDefaultTranslation = defaultTranslation;
-        mMiwokTranslation = miwokTranslation;
+        mDefaultTranslationId = defaultTranslationId;
+        mMiwokTranslationId = miwokTranslationId;
         mImageResourceId = imageResourceId;
         mAudioResourceId = audioResourceId;
     }
@@ -56,15 +56,15 @@ public class Word {
     /**
      * Get the default translation of the word.
      */
-    public String getDefaultTranslation() {
-        return mDefaultTranslation;
+    public int getDefaultTranslationId() {
+        return mDefaultTranslationId;
     }
 
     /**
      * Get the Miwok translation of the word.
      */
-    public String getMiwokTranslation() {
-        return mMiwokTranslation;
+    public int getMiwokTranslationId() {
+        return mMiwokTranslationId;
     }
 
     /**
@@ -94,8 +94,8 @@ public class Word {
     @Override
     public String toString() {
         return "Word{" +
-                "mDefaultTranslation='" + mDefaultTranslation + '\'' +
-                ", mMiwokTranslation='" + mMiwokTranslation + '\'' +
+                "mDefaultTranslationId='" + mDefaultTranslationId + '\'' +
+                ", mMiwokTranslationId='" + mMiwokTranslationId + '\'' +
                 ", mAudioResourceId=" + mAudioResourceId +
                 ", mImageResourceId=" + mImageResourceId +
                 '}';

--- a/app/src/main/java/com/example/android/miwok/WordAdapter.java
+++ b/app/src/main/java/com/example/android/miwok/WordAdapter.java
@@ -48,13 +48,13 @@ public class WordAdapter extends ArrayAdapter<Word>  {
         TextView defaultTextView = (TextView) listItemView.findViewById(R.id.default_text_view);
         // Get the default translation from the currentWord object and set this text on
         // the default TextView.
-        defaultTextView.setText(currentWord.getDefaultTranslation());
+        defaultTextView.setText(getContext().getString(currentWord.getDefaultTranslationId()));
 
         // Find the TextView in the list_item.xml layout with the ID miwok_text_view.
         TextView miwokTextView = (TextView) listItemView.findViewById(R.id.miwok_text_view);
         // Get the Miwok translation from the currentWord object and set this text on
         // the default TextView.
-        miwokTextView.setText(currentWord.getMiwokTranslation());
+        miwokTextView.setText(getContext().getString(currentWord.getMiwokTranslationId()));
 
         // Find the ImageView in the list_item.xml layout with the ID image.
         ImageView imageView = (ImageView) listItemView.findViewById(R.id.image);

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -32,8 +32,8 @@
     <string name="miwok_number_six">temmokka</string>
     <string name="miwok_number_seven">kenekaku</string>
     <string name="miwok_number_eight">kawinta</string>
-    <string name="miwok_number_nine">wo’e</string>
-    <string name="miwok_number_ten">na’aacha</string>
+    <string name="miwok_number_nine">wo\'e</string>
+    <string name="miwok_number_ten">na\'aacha</string>
 
     <!-- Miwok vocabulary words for phrases -->
     <string name="miwok_phrase_where_are_you_going">minto wuksus</string>
@@ -42,7 +42,7 @@
     <string name="miwok_phrase_how_are_you_feeling">michәksәs?</string>
     <string name="miwok_phrase_im_feeling_good">kuchi achit</string>
     <string name="miwok_phrase_are_you_coming">әәnәs\'aa?</string>
-    <string name="miwok_phrase_yes_im_coming">hәә’ әәnәm</string>
+    <string name="miwok_phrase_yes_im_coming">hәә\' әәnәm</string>
     <string name="miwok_phrase_im_coming">әәnәm</string>
     <string name="miwok_phrase_lets_go">yoowutis</string>
     <string name="miwok_phrase_come_here">әnni\'nem</string>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <!-- Miwok vocabulary words for colors -->
+    <!-- Miwok vocabulary words for colors [CHAR LIMIT=20] -->
     <string name="miwok_color_red">weṭeṭṭi</string>
     <string name="miwok_color_dusty_yellow">ṭopiisә</string>
     <string name="miwok_color_mustard_yellow">chiwiiṭә</string>
@@ -11,7 +11,7 @@
     <string name="miwok_color_gray">ṭopoppi</string>
     <string name="miwok_color_white">kelelli</string>
 
-    <!-- Miwok vocabulary words for family -->
+    <!-- Miwok vocabulary words for family [CHAR LIMIT=20] -->
     <string name="miwok_family_father">әpә</string>
     <string name="miwok_family_mother">әṭa</string>
     <string name="miwok_family_son">angsi</string>
@@ -23,7 +23,7 @@
     <string name="miwok_family_grandmother">ama</string>
     <string name="miwok_family_grandfather">paapa</string>
 
-    <!-- Miwok vocabulary words for numbers -->
+    <!-- Miwok vocabulary words for numbers [CHAR LIMIT=20] -->
     <string name="miwok_number_one">lutti</string>
     <string name="miwok_number_two">otiiko</string>
     <string name="miwok_number_three">tolookosu</string>
@@ -35,7 +35,7 @@
     <string name="miwok_number_nine">wo\'e</string>
     <string name="miwok_number_ten">na\'aacha</string>
 
-    <!-- Miwok vocabulary words for phrases -->
+    <!-- Miwok vocabulary words for phrases [CHAR LIMIT=20] -->
     <string name="miwok_phrase_where_are_you_going">minto wuksus</string>
     <string name="miwok_phrase_what_is_your_name">tinnә oyaase\'nә</string>
     <string name="miwok_phrase_my_name_is">oyaaset...</string>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <!-- Miwok vocabulary words for colors [CHAR LIMIT=20] -->
+    <!-- Miwok translation for colors -->
     <string name="miwok_color_red">weṭeṭṭi</string>
     <string name="miwok_color_dusty_yellow">ṭopiisә</string>
     <string name="miwok_color_mustard_yellow">chiwiiṭә</string>
@@ -11,7 +11,7 @@
     <string name="miwok_color_gray">ṭopoppi</string>
     <string name="miwok_color_white">kelelli</string>
 
-    <!-- Miwok vocabulary words for family [CHAR LIMIT=20] -->
+    <!-- Miwok translation for family -->
     <string name="miwok_family_father">әpә</string>
     <string name="miwok_family_mother">әṭa</string>
     <string name="miwok_family_son">angsi</string>
@@ -23,7 +23,7 @@
     <string name="miwok_family_grandmother">ama</string>
     <string name="miwok_family_grandfather">paapa</string>
 
-    <!-- Miwok vocabulary words for numbers [CHAR LIMIT=20] -->
+    <!-- Miwok translation for numbers -->
     <string name="miwok_number_one">lutti</string>
     <string name="miwok_number_two">otiiko</string>
     <string name="miwok_number_three">tolookosu</string>
@@ -35,7 +35,7 @@
     <string name="miwok_number_nine">wo\'e</string>
     <string name="miwok_number_ten">na\'aacha</string>
 
-    <!-- Miwok vocabulary words for phrases [CHAR LIMIT=20] -->
+    <!-- Miwok translation for phrases -->
     <string name="miwok_phrase_where_are_you_going">minto wuksus</string>
     <string name="miwok_phrase_what_is_your_name">tinnә oyaase\'nә</string>
     <string name="miwok_phrase_my_name_is">oyaaset...</string>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- Miwok vocabulary words for colors -->
+    <string name="miwok_color_red">weṭeṭṭi</string>
+    <string name="miwok_color_dusty_yellow">ṭopiisә</string>
+    <string name="miwok_color_mustard_yellow">chiwiiṭә</string>
+    <string name="miwok_color_green">chokokki</string>
+    <string name="miwok_color_brown">ṭakaakki</string>
+    <string name="miwok_color_black">kululli</string>
+    <string name="miwok_color_gray">ṭopoppi</string>
+    <string name="miwok_color_white">kelelli</string>
+
+    <!-- Miwok vocabulary words for family -->
+    <string name="miwok_family_father">әpә</string>
+    <string name="miwok_family_mother">әṭa</string>
+    <string name="miwok_family_son">angsi</string>
+    <string name="miwok_family_daughter">tune</string>
+    <string name="miwok_family_older_brother">taachi</string>
+    <string name="miwok_family_younger_brother">chalitti</string>
+    <string name="miwok_family_older_sister">teṭe</string>
+    <string name="miwok_family_younger_sister">kolliti</string>
+    <string name="miwok_family_grandmother">ama</string>
+    <string name="miwok_family_grandfather">paapa</string>
+
+    <!-- Miwok vocabulary words for numbers -->
+    <string name="miwok_number_one">lutti</string>
+    <string name="miwok_number_two">otiiko</string>
+    <string name="miwok_number_three">tolookosu</string>
+    <string name="miwok_number_four">oyyisa</string>
+    <string name="miwok_number_five">massokka</string>
+    <string name="miwok_number_six">temmokka</string>
+    <string name="miwok_number_seven">kenekaku</string>
+    <string name="miwok_number_eight">kawinta</string>
+    <string name="miwok_number_nine">wo’e</string>
+    <string name="miwok_number_ten">na’aacha</string>
+
+    <!-- Miwok vocabulary words for phrases -->
+    <string name="miwok_phrase_where_are_you_going">minto wuksus</string>
+    <string name="miwok_phrase_what_is_your_name">tinnә oyaase\'nә</string>
+    <string name="miwok_phrase_my_name_is">oyaaset...</string>
+    <string name="miwok_phrase_how_are_you_feeling">michәksәs?</string>
+    <string name="miwok_phrase_im_feeling_good">kuchi achit</string>
+    <string name="miwok_phrase_are_you_coming">әәnәs\'aa?</string>
+    <string name="miwok_phrase_yes_im_coming">hәә’ әәnәm</string>
+    <string name="miwok_phrase_im_coming">әәnәm</string>
+    <string name="miwok_phrase_lets_go">yoowutis</string>
+    <string name="miwok_phrase_come_here">әnni\'nem</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,7 +14,7 @@
     <!-- Category name for the vocabulary words for family members [CHAR LIMIT=20] -->
     <string name="category_family">Family Members</string>
 
-    <!-- Vocabulary words for colors -->
+    <!-- Vocabulary words for colors [CHAR LIMIT=20] -->
     <string name="color_red">red</string>
     <string name="color_dusty_yellow">dusty yellow</string>
     <string name="color_mustard_yellow">mustard yellow</string>
@@ -24,7 +24,7 @@
     <string name="color_gray">gray</string>
     <string name="color_white">white</string>
 
-    <!-- Vocabulary words for numbers -->
+    <!-- Vocabulary words for numbers [CHAR LIMIT=20] -->
     <string name="number_one">one</string>
     <string name="number_two">two</string>
     <string name="number_three">three</string>
@@ -36,7 +36,7 @@
     <string name="number_nine">nine</string>
     <string name="number_ten">ten</string>
 
-    <!-- Vocabulary words for family -->
+    <!-- Vocabulary words for family [CHAR LIMIT=20] -->
     <string name="family_father">father</string>
     <string name="family_mother">mother</string>
     <string name="family_son">son</string>
@@ -48,7 +48,7 @@
     <string name="family_grandmother">grandmother</string>
     <string name="family_grandfather">grandfather</string>
 
-    <!-- Vocabulary words for phrases -->
+    <!-- Vocabulary words for phrases [CHAR LIMIT=30] -->
     <string name="phrase_where_are_you_going">Where are you going?</string>
     <string name="phrase_what_is_your_name">What is your name?</string>
     <string name="phrase_my_name_is">My name is...</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -53,10 +53,10 @@
     <string name="phrase_what_is_your_name">What is your name?</string>
     <string name="phrase_my_name_is">My name is...</string>
     <string name="phrase_how_are_you_feeling">How are you feeling?</string>
-    <string name="phrase_im_feeling_good">I’m feeling good.</string>
+    <string name="phrase_im_feeling_good">I\'m feeling good.</string>
     <string name="phrase_are_you_coming">Are you coming?</string>
-    <string name="phrase_yes_im_coming">Yes, I’m coming.</string>
-    <string name="phrase_im_coming">I’m coming.</string>
-    <string name="phrase_lets_go">Let’s go.</string>
+    <string name="phrase_yes_im_coming">"Yes, I\'m coming."</string>
+    <string name="phrase_im_coming">I\'m coming.</string>
+    <string name="phrase_lets_go">Let\'s go.</string>
     <string name="phrase_come_here">Come here.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,4 +13,50 @@
 
     <!-- Category name for the vocabulary words for family members [CHAR LIMIT=20] -->
     <string name="category_family">Family Members</string>
+
+    <!-- Vocabulary words for colors -->
+    <string name="color_red">red</string>
+    <string name="color_dusty_yellow">dusty yellow</string>
+    <string name="color_mustard_yellow">mustard yellow</string>
+    <string name="color_green">green</string>
+    <string name="color_brown">brown</string>
+    <string name="color_black">black</string>
+    <string name="color_gray">gray</string>
+    <string name="color_white">white</string>
+
+    <!-- Vocabulary words for numbers -->
+    <string name="number_one">one</string>
+    <string name="number_two">two</string>
+    <string name="number_three">three</string>
+    <string name="number_four">four</string>
+    <string name="number_five">five</string>
+    <string name="number_six">six</string>
+    <string name="number_seven">seven</string>
+    <string name="number_eight">eight</string>
+    <string name="number_nine">nine</string>
+    <string name="number_ten">ten</string>
+
+    <!-- Vocabulary words for family -->
+    <string name="family_father">father</string>
+    <string name="family_mother">mother</string>
+    <string name="family_son">son</string>
+    <string name="family_daughter">daughter</string>
+    <string name="family_older_brother">older brother</string>
+    <string name="family_younger_brother">younger brother</string>
+    <string name="family_older_sister">older sister</string>
+    <string name="family_younger_sister">younger sister</string>
+    <string name="family_grandmother">grandmother</string>
+    <string name="family_grandfather">grandfather</string>
+
+    <!-- Vocabulary words for phrases -->
+    <string name="phrase_where_are_you_going">Where are you going?</string>
+    <string name="phrase_what_is_your_name">What is your name?</string>
+    <string name="phrase_my_name_is">My name is...</string>
+    <string name="phrase_how_are_you_feeling">How are you feeling?</string>
+    <string name="phrase_im_feeling_good">I’m feeling good.</string>
+    <string name="phrase_are_you_coming">Are you coming?</string>
+    <string name="phrase_yes_im_coming">Yes, I’m coming.</string>
+    <string name="phrase_im_coming">I’m coming.</string>
+    <string name="phrase_lets_go">Let’s go.</string>
+    <string name="phrase_come_here">Come here.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,49 +14,117 @@
     <!-- Category name for the vocabulary words for family members [CHAR LIMIT=20] -->
     <string name="category_family">Family Members</string>
 
-    <!-- Vocabulary words for colors [CHAR LIMIT=20] -->
+    <!-- Default translation for the red color [CHAR LIMIT=20] -->
     <string name="color_red">red</string>
+
+    <!-- Default translation for the dusty yellow color [CHAR LIMIT=20] -->
     <string name="color_dusty_yellow">dusty yellow</string>
+
+    <!-- Default translation for the mustard yellow color [CHAR LIMIT=20] -->
     <string name="color_mustard_yellow">mustard yellow</string>
+
+    <!-- Default translation for the green color [CHAR LIMIT=20] -->
     <string name="color_green">green</string>
+
+    <!-- Default translation for the brown color [CHAR LIMIT=20] -->
     <string name="color_brown">brown</string>
+
+    <!-- Default translation for the black color [CHAR LIMIT=20] -->
     <string name="color_black">black</string>
+
+    <!-- Default translation for the gray color [CHAR LIMIT=20] -->
     <string name="color_gray">gray</string>
+
+    <!-- Default translation for the white color [CHAR LIMIT=20] -->
     <string name="color_white">white</string>
 
-    <!-- Vocabulary words for numbers [CHAR LIMIT=20] -->
+    <!-- Default translation for the number one [CHAR LIMIT=20] -->
     <string name="number_one">one</string>
+
+    <!-- Default translation for the number two [CHAR LIMIT=20] -->
     <string name="number_two">two</string>
+
+    <!-- Default translation for the number three [CHAR LIMIT=20] -->
     <string name="number_three">three</string>
+
+    <!-- Default translation for the number four [CHAR LIMIT=20] -->
     <string name="number_four">four</string>
+
+    <!-- Default translation for the number five [CHAR LIMIT=20] -->
     <string name="number_five">five</string>
+
+    <!-- Default translation for the number six [CHAR LIMIT=20] -->
     <string name="number_six">six</string>
+
+    <!-- Default translation for the number seven [CHAR LIMIT=20] -->
     <string name="number_seven">seven</string>
+
+    <!-- Default translation for the number eight [CHAR LIMIT=20] -->
     <string name="number_eight">eight</string>
+
+    <!-- Default translation for the number nine [CHAR LIMIT=20] -->
     <string name="number_nine">nine</string>
+
+    <!-- Default translation for the number ten [CHAR LIMIT=20] -->
     <string name="number_ten">ten</string>
 
-    <!-- Vocabulary words for family [CHAR LIMIT=20] -->
+    <!-- Default translation for "father" [CHAR LIMIT=20] -->
     <string name="family_father">father</string>
+
+    <!-- Default translation for "mother" [CHAR LIMIT=20] -->
     <string name="family_mother">mother</string>
+
+    <!-- Default translation for "son" [CHAR LIMIT=20] -->
     <string name="family_son">son</string>
+
+    <!-- Default translation for "daughter" [CHAR LIMIT=20] -->
     <string name="family_daughter">daughter</string>
+
+    <!-- Default translation for "older brother" [CHAR LIMIT=20] -->
     <string name="family_older_brother">older brother</string>
+
+    <!-- Default translation for "younger brother" [CHAR LIMIT=20] -->
     <string name="family_younger_brother">younger brother</string>
+
+    <!-- Default translation for "older sister" [CHAR LIMIT=20] -->
     <string name="family_older_sister">older sister</string>
+
+    <!-- Default translation for "younger sister" [CHAR LIMIT=20] -->
     <string name="family_younger_sister">younger sister</string>
+
+    <!-- Default translation for "grandmother" [CHAR LIMIT=20] -->
     <string name="family_grandmother">grandmother</string>
+
+    <!-- Default translation for "grandfather" [CHAR LIMIT=20] -->
     <string name="family_grandfather">grandfather</string>
 
-    <!-- Vocabulary words for phrases [CHAR LIMIT=30] -->
+    <!-- Default translation for "Where are you going?" [CHAR LIMIT=30] -->
     <string name="phrase_where_are_you_going">Where are you going?</string>
+
+    <!-- Default translation for "What is your name?" [CHAR LIMIT=20] -->
     <string name="phrase_what_is_your_name">What is your name?</string>
+
+    <!-- Default translation for "My name is..." [CHAR LIMIT=20] -->
     <string name="phrase_my_name_is">My name is...</string>
+
+    <!-- Default translation for "How are you feeling?" [CHAR LIMIT=20] -->
     <string name="phrase_how_are_you_feeling">How are you feeling?</string>
+
+    <!-- Default translation for "I'm feeling good." [CHAR LIMIT=20] -->
     <string name="phrase_im_feeling_good">I\'m feeling good.</string>
+
+    <!-- Default translation for "Are you coming?" [CHAR LIMIT=20] -->
     <string name="phrase_are_you_coming">Are you coming?</string>
+
+    <!-- Default translation for "Yes, I'm coming." [CHAR LIMIT=20] -->
     <string name="phrase_yes_im_coming">"Yes, I\'m coming."</string>
+
+    <!-- Default translation for "I'm coming." [CHAR LIMIT=20] -->
     <string name="phrase_im_coming">I\'m coming.</string>
+
+    <!-- Default translation for "Let's go." [CHAR LIMIT=20] -->
     <string name="phrase_lets_go">Let\'s go.</string>
+
+    <!-- Default translation for "Come here." [CHAR LIMIT=20] -->
     <string name="phrase_come_here">Come here.</string>
 </resources>


### PR DESCRIPTION
Addresses #22.

I'm not exactly sure what value to put for the CHAR LIMIT. Also, I only put a "header" comment to describe each group of strings (colors, family, phrase), instead of a comment per string.

Another thing is that the Word class constructor still accepts two strings (one for the default-translated word, and the other for the Miwok equivalent). Should that instead be the Resource ID so that the signature takes all resource IDs? Instead of the method signatures:

```
public Word(String, String, int, int)
public Word(String, String, int)
```

it would be

```
public Word(int, int, int, int)
public Word(int, int, int)
```

Of course, that would change the accessor signatures (`public int getDefaultTransactionId()` instead of `public String getDefaultTransaction()`) and the Word callers (e.g., the WordAdapter) would be responsible of getting the string resource instead of the constructor call.